### PR TITLE
Smooth heist payout curve & fix error when taking less than 10 seconds

### DIFF
--- a/src/main/java/dev/darealturtywurty/superturtybot/commands/levelling/LevellingManager.java
+++ b/src/main/java/dev/darealturtywurty/superturtybot/commands/levelling/LevellingManager.java
@@ -329,7 +329,7 @@ public final class LevellingManager extends ListenerAdapter {
     }
 
     public static int getXPForLevel(final int level) {
-        return (int) (5 * Math.pow(level, 2) + 50 * level + 5);
+        return 5 * level * level + 50 * level + 5;
     }
 
     public void setXP(Guild guild, User user1, int amount) {

--- a/src/main/java/dev/darealturtywurty/superturtybot/modules/economy/EconomyManager.java
+++ b/src/main/java/dev/darealturtywurty/superturtybot/modules/economy/EconomyManager.java
@@ -380,12 +380,12 @@ public class EconomyManager {
     // Should exponentially increase the cost and payout of a heist based on the user's account
     public static long determineHeistSetupCost(Economy account) {
         int heistLevel = account.getHeistLevel();
-        return (long) Math.pow(heistLevel, 2) * 100_000L;
+        return 100_000L * heistLevel * heistLevel;
     }
 
     private static long determineHeistPayout(Economy account) {
         int heistLevel = account.getHeistLevel();
-        return (long) Math.pow(heistLevel, 2) * ThreadLocalRandom.current().nextLong(200_000, 500_000);
+        return ThreadLocalRandom.current().nextLong(200_000, 500_000) * heistLevel * heistLevel;
     }
 
     /**
@@ -396,7 +396,7 @@ public class EconomyManager {
      */
     public static Pair<Long, Boolean> heistCompleted(Economy account, long timeTaken) {
         long payout = determineHeistPayout(account);
-        long earned = payout / (timeTaken / 10_000) + determineHeistSetupCost(account);
+        long earned = payout * 10_000L / timeTaken + determineHeistSetupCost(account);
         addMoney(account, earned, true);
 
         account.setTotalHeists(account.getTotalHeists() + 1);


### PR DESCRIPTION
and turn some Math.pow(x, 2) to x * x
TEST: <@813400455149387857>
previous graph = red
new graph = purple
(y axis not to scale)
![image](https://github.com/user-attachments/assets/d6f48000-2c61-4008-bccb-be4bf1b1eaeb)